### PR TITLE
Fix regex, tidy up npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "example": "cd example && ./../node_modules/.bin/babel-node app.js",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "prepublish": "npm run lint && npm run build",
-    "lint": "./node_modules/.bin/eslint ./src",
-    "test": "./node_modules/.bin/babel-node -- ./node_modules/.bin/babel-istanbul cover --report lcov _mocha "
+    "lint": "eslint ./src",
+    "test": "babel-node -- ./node_modules/.bin/babel-istanbul cover --report lcov _mocha "
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",

--- a/src/utils/loader.js
+++ b/src/utils/loader.js
@@ -1,7 +1,7 @@
 import { loadPackageJSON, mergeDeep } from './../utils';
 
 const hookPrefix = 'redibox-hook';
-const hookRegexReplace = new RegExp(`@?[a-zA-Z-_0-9.]*?\/?${hookPrefix}-`);
+const hookRegexReplace = new RegExp(`@?[a-zA-Z-_0-9.]*?${hookPrefix}-`);
 
 /**
  *


### PR DESCRIPTION
* I'm not 100% convinced that my fix to the regex actually works, but with the `/` character that has been getting the eslint error: "no-useless-escape" being optional due to the `?` that follows it I think it can be safely removed (Tested in [https://regex101.com/r/trH9Vy/1/](https://regex101.com/r/trH9Vy/1/)

* Remove unnecessary references to `./node_modules/.bin/[package-name]`.  By default npm scripts will look into `./node_modules/bin` before looking into global installs _ref:_ [https://firstdoit.com/no-need-for-globals-using-npm-dependencies-in-npm-scripts-3dfb478908#3d3a](https://firstdoit.com/no-need-for-globals-using-npm-dependencies-in-npm-scripts-3dfb478908#3d3a)