### PR TITLE
Add utility tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "prepublish": "npm run lint && npm run build",
     "lint": "eslint ./src",
-    "unit": "jest",
+    "unit": "jest --forceExit",
     "test": "jest --forceExit --coverage",
     "showcoverage": "http-server coverage -p 7000 -o"
   },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "prepublish": "npm run lint && npm run build",
     "lint": "eslint ./src",
-    "unit": "jest --forceExit",
+    "unit": "jest",
     "test": "jest --forceExit --coverage",
     "showcoverage": "http-server coverage -p 7000 -o"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "prepublish": "npm run lint && npm run build",
     "lint": "eslint ./src",
     "unit": "jest --forceExit",
-    "test": "jest --forceExit --coverage"
+    "test": "jest --forceExit --coverage",
+    "showcoverage": "http-server coverage -p 7000 -o"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -53,6 +54,7 @@
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-react": "^7.1.0",
+    "http-server": "^0.10.0",
     "isparta": "^4.0.0",
     "jest": "^20.0.4"
   },
@@ -62,5 +64,14 @@
     "eventemitter3": "^2.0.3",
     "ioredis": "^2.3.0",
     "winston": "^2.3.1"
+  },
+  "jest": {
+    "rootDir": "./src",
+    "resetMocks": true,
+    "resetModules": true,
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "<rootDir>/utils/aliases.js"
+    ]
   }
 }

--- a/src/__tests__/cluster/core-cluster-test.js
+++ b/src/__tests__/cluster/core-cluster-test.js
@@ -57,6 +57,7 @@ describe('cluster', () => {
       done();
     });
     redibox.on('error', (e) => {
+      // eslint-disable-next-line no-console
       console.error(e);
     });
   });

--- a/src/__tests__/cluster/core-cluster-test.js
+++ b/src/__tests__/cluster/core-cluster-test.js
@@ -1,4 +1,4 @@
-const RediBox = require('../../index').default;
+const RediBox = require('../../').default;
 
 const clusterConfig = {
   log: { level: 'error' },

--- a/src/__tests__/cluster/core-cluster-test.js
+++ b/src/__tests__/cluster/core-cluster-test.js
@@ -1,4 +1,4 @@
-const RediBox = require('../../src/index').default;
+const RediBox = require('../../index').default;
 
 const clusterConfig = {
   log: { level: 'error' },

--- a/src/__tests__/core/index.js
+++ b/src/__tests__/core/index.js
@@ -1,4 +1,4 @@
-const RediBox = require('../../index').default;
+const RediBox = require('../../').default;
 
 describe('core', () => {
   it('Should error when connecting to a offline redis server', (done) => {

--- a/src/__tests__/core/index.js
+++ b/src/__tests__/core/index.js
@@ -1,4 +1,4 @@
-const RediBox = require('../../src/index').default;
+const RediBox = require('../../index').default;
 
 describe('core', () => {
   it('Should error when connecting to a offline redis server', (done) => {

--- a/src/__tests__/hooks/cluster.js
+++ b/src/__tests__/hooks/cluster.js
@@ -43,6 +43,7 @@ describe('core hooks - cluster', () => {
       done();
     });
     redibox.on('error', (e) => {
+      // eslint-disable-next-line no-console
       console.error(e);
     });
   });
@@ -62,6 +63,7 @@ describe('core hooks - cluster', () => {
       done();
     });
     redibox.on('error', (e) => {
+      // eslint-disable-next-line no-console
       console.error(e);
     });
   });
@@ -81,11 +83,12 @@ describe('core hooks - cluster', () => {
       done();
     });
     redibox.on('error', (e) => {
+      // eslint-disable-next-line no-console
       console.error(e);
     });
   });
 
-  it('Should return an array of all redis node addresses', function testB(done) {
+  it('Should return an array of all redis node addresses', (done) => {
     const redibox = new RediBox(clusterConfig, () => {
       expect(redibox.options.redis.cluster).toBe(true);
       expect(typeof redibox.clients.default.connectionPool.nodes.all).toBe('object');
@@ -105,6 +108,7 @@ describe('core hooks - cluster', () => {
       done();
     });
     redibox.on('error', (e) => {
+      // eslint-disable-next-line no-console
       console.error(e);
     });
   });
@@ -118,6 +122,7 @@ describe('core hooks - cluster', () => {
       done();
     });
     redibox.on('error', (e) => {
+      // eslint-disable-next-line no-console
       console.error(e);
     });
   });

--- a/src/__tests__/hooks/cluster.js
+++ b/src/__tests__/hooks/cluster.js
@@ -1,4 +1,4 @@
-const RediBox = require('../../index').default;
+const RediBox = require('../../').default;
 
 const clusterConfig = {
   log: { level: 'error' },

--- a/src/__tests__/hooks/cluster.js
+++ b/src/__tests__/hooks/cluster.js
@@ -1,4 +1,4 @@
-const RediBox = require('../../src/index').default;
+const RediBox = require('../../index').default;
 
 const clusterConfig = {
   log: { level: 'error' },

--- a/src/__tests__/hooks/loader.js
+++ b/src/__tests__/hooks/loader.js
@@ -1,5 +1,5 @@
-const RediBox = require('../../src/index').default;
-const { BaseHook } = require('../../src/index');
+const RediBox = require('../../index').default;
+const { BaseHook } = require('../../index');
 
 class CoolHook extends BaseHook {
   constructor() {

--- a/src/__tests__/hooks/loader.js
+++ b/src/__tests__/hooks/loader.js
@@ -1,5 +1,5 @@
-const RediBox = require('../../index').default;
-const { BaseHook } = require('../../index');
+const RediBox = require('../../').default;
+const { BaseHook } = require('../../');
 
 class CoolHook extends BaseHook {
   constructor() {

--- a/src/__tests__/hooks/loader.js
+++ b/src/__tests__/hooks/loader.js
@@ -55,12 +55,14 @@ describe('core hooks - loader', () => {
         cool: CoolHook,
       },
     }, () => {
+      // eslint-disable-next-line no-prototype-builtins
       expect(redibox.hooks.hasOwnProperty('cool')).toBe(true);
       expect(redibox.hooks.cool.getClientCount()).toBe(1);
       redibox.disconnect();
       done();
     });
     redibox.on('error', (e) => {
+      // eslint-disable-next-line no-console
       console.error(e);
     });
   });
@@ -71,12 +73,14 @@ describe('core hooks - loader', () => {
         cool: CoolHook,
       },
     }, () => {
+      // eslint-disable-next-line no-prototype-builtins
       expect(redibox.hooks.cool.options.hasOwnProperty('kittenSays')).toBe(true);
       expect(redibox.hooks.cool.options.kittenSays).toBe('meow');
       redibox.disconnect();
       done();
     });
     redibox.on('error', (e) => {
+      // eslint-disable-next-line no-console
       console.error(e);
     });
   });
@@ -87,6 +91,7 @@ describe('core hooks - loader', () => {
         cool: CoolHook,
       },
     }, () => {
+      /* eslint-disable no-prototype-builtins */
       expect(redibox.hooks.hasOwnProperty('cool')).toBe(true);
       redibox.hooks.cool._unmount();
       expect(redibox.hooks.hasOwnProperty('cool')).toBe(false);
@@ -95,8 +100,10 @@ describe('core hooks - loader', () => {
       expect(redibox.hasOwnProperty('cluster')).toBe(false);
       redibox.disconnect();
       done();
+      /* eslint-enable */
     });
     redibox.on('error', (e) => {
+      // eslint-disable-next-line no-console
       console.error(e);
     });
   });

--- a/src/__tests__/hooks/pubsub.js
+++ b/src/__tests__/hooks/pubsub.js
@@ -26,6 +26,7 @@ describe('core hooks - pubsub', () => {
     const redibox = new RediBox({ pubsub: { subscriber: true, publisher: true } });
 
     redibox.on('error', (error) => {
+      // eslint-disable-next-line no-console
       console.dir(error);
     });
 
@@ -63,6 +64,7 @@ describe('core hooks - pubsub', () => {
     const redibox = new RediBox({ pubsub: { subscriber: true, publisher: true } });
 
     redibox.on('error', (error) => {
+      // eslint-disable-next-line no-console
       console.dir(error);
     });
 
@@ -88,6 +90,7 @@ describe('core hooks - pubsub', () => {
     const redibox = new RediBox({ pubsub: { subscriber: true, publisher: true } });
 
     redibox.on('error', (error) => {
+      // eslint-disable-next-line no-console
       console.dir(error);
     });
 
@@ -165,6 +168,7 @@ describe('core hooks - pubsub', () => {
     const redibox = new RediBox({ pubsub: { subscriber: true, publisher: true } });
 
     redibox.on('error', (error) => {
+      // eslint-disable-next-line no-console
       console.dir(error);
     });
 

--- a/src/__tests__/hooks/pubsub.js
+++ b/src/__tests__/hooks/pubsub.js
@@ -1,5 +1,5 @@
-const RediBox = require('../../src/index').default;
-const { after } = require('../../src/index');
+const RediBox = require('../../index').default;
+const { after } = require('../../index');
 
 describe('core hooks - pubsub', () => {
   it('Should create a subscriber client if option set', (done) => {

--- a/src/__tests__/hooks/pubsub.js
+++ b/src/__tests__/hooks/pubsub.js
@@ -1,5 +1,5 @@
-const RediBox = require('../../index').default;
-const { after } = require('../../index');
+const RediBox = require('../../').default;
+const { after } = require('../../');
 
 describe('core hooks - pubsub', () => {
   it('Should create a subscriber client if option set', (done) => {

--- a/src/__tests__/utils/index.js
+++ b/src/__tests__/utils/index.js
@@ -288,9 +288,9 @@ describe('utils', () => {
     });
 
     it('catches JSON stringify errors', () => {
-      const a = {};
-      a.b = a;
-      expect(tryJSONStringify(a)).toBeUndefined();
+      const badData = {};
+      badData.prop = badData;
+      expect(tryJSONStringify(badData)).toBeUndefined();
     });
   });
 

--- a/src/__tests__/utils/index.js
+++ b/src/__tests__/utils/index.js
@@ -1,0 +1,258 @@
+const { loadPackageJSON,
+  tryJSONStringify,
+  tryJSONParse,
+  arrayChunks,
+  mergeDeep,
+  isObject,
+  createLogger,
+  nodify,
+  noop,
+  isFunction,
+  once,
+  after,
+  deepGet,
+  throttle,
+  getTimeStamp,
+  sha1sum,
+} = require('../../utils/index');
+
+const { dateNow } = require('../../utils/aliases');
+
+jest.mock('../../utils/aliases');
+
+describe('utils', () => {
+  describe('sha1sum', () => {
+    it('Returns a sha1 hash from a passed object', () => {
+      expect(sha1sum({ test: 'hello-test' }))
+        .toEqual('f92c4be69dec078332c2997b4534c971f193c9fd');
+    });
+  });
+
+  describe('getTimeStamp', () => {
+    it('caches and returns the current timestamp for 50ms or 1000 calls', (done) => {
+      dateNow.mockImplementation(() => +new Date('2017-07-17'));
+      getTimeStamp();
+      getTimeStamp();
+      expect(getTimeStamp()).toEqual(1500249600000);
+      expect(dateNow).toHaveBeenCalledTimes(1);
+
+      let limit = 1001;
+      while (limit > 0) {
+        getTimeStamp();
+        limit -= 1;
+      }
+      expect(dateNow).toHaveBeenCalledTimes(2);
+
+      setTimeout(() => {
+        getTimeStamp();
+        getTimeStamp();
+        expect(dateNow).toHaveBeenCalledTimes(3);
+        done();
+      }, 60);
+    });
+  });
+
+  describe('throttle', () => {
+    it('throttles calls to a passed function by a defined time limit', (done) => {
+      const mockFn = jest.fn();
+      const limit = 50;
+      const throttled = throttle(mockFn, limit);
+      throttled('test1');
+      throttled('test2');
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith('test1');
+      setTimeout(() => {
+        throttled('test3');
+        throttled('test4');
+        expect(mockFn).toHaveBeenCalledTimes(2);
+        expect(mockFn).toHaveBeenCalledWith('test3');
+        done();
+      }, limit + 10);
+    });
+  });
+
+
+  describe('deepGet', () => {
+    const testObj = { a: 'testValA', b: { c: { d: 'testValD' } } };
+
+    it('returns the value for an object property based on dot-notation path', () => {
+      expect(deepGet(testObj, 'a')).toEqual('testValA');
+      expect(deepGet(testObj, 'b.c.d')).toEqual('testValD');
+    });
+
+    it('returns "null" when passed no object', () => {
+      expect(deepGet(testObj, 'd')).toBeNull();
+    });
+  });
+
+  describe('after', () => {
+    it('calls the callback after a set call-count threshold has elapsed', () => {
+      const mockFn = jest.fn();
+      const threshold = 2;
+      const wrapper = after(threshold, mockFn);
+      wrapper();
+      expect(mockFn).toHaveBeenCalledTimes(0);
+      wrapper();
+      expect(mockFn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('once', () => {
+    it('allows the callback to be called once only', () => {
+      const mockFn = jest.fn();
+      const wrapper = once(mockFn);
+      wrapper('arg1', 'arg2');
+      wrapper('foo', 'bar');
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith('arg1', 'arg2');
+    });
+
+    it('can take context', () => {
+      const mockFn = jest.fn();
+      const testContext = { foo: 'test' };
+      const wrapper = once(mockFn, testContext);
+      wrapper('arg1', 'arg2');
+      expect(mockFn.mock.instances[0]).toEqual(testContext);
+    });
+  });
+
+  describe('isFunction', () => {
+    it('returns true if function', () => {
+      expect(isFunction(jest.fn())).toBe(true);
+      expect(isFunction('no-a-function')).toBe(false);
+    });
+  });
+
+  describe('noop', () => {
+    it('returns undefined', () => {
+      expect(noop()).toBeUndefined();
+      expect(noop(1)).toBeUndefined();
+    });
+
+    it('doesn\'t call any passed functions', () => {
+      const mockFn = jest.fn();
+      noop(mockFn);
+      expect(mockFn).not.toBeCalled();
+    });
+  });
+
+  describe('nodify', () => {
+    it('if no callback passed returns the promise', () => {
+      const testPromise = Promise.resolve('test success');
+      expect(nodify(testPromise)).toBe(testPromise);
+    });
+
+    it('calls the callback with resolved promise value', (done) => {
+      const testPromise = Promise.resolve('test success');
+      const callback = jest.fn();
+      nodify(testPromise, callback);
+      setTimeout(() => {
+        expect(callback).toHaveBeenCalledWith(null, 'test success');
+        done();
+      }, 20);
+    });
+
+    it('handles errors', () => {
+      const testPromise = Promise.resolve('test success');
+      const callback = undefined
+      nodify(testPromise, callback);
+    });
+  });
+
+  describe('createLogger', () => {
+    it('returns a new instance of winston logger with console transport only', () => {
+      expect(createLogger().transports).toMatchObject({
+        console: {
+          silent: false,
+        },
+      });
+    });
+
+    it('takes an options object that can be used to override transport defaults', () => {
+      const options = {
+        silent: true,
+      };
+      expect(createLogger(options).transports).toMatchObject({
+        console: {
+          silent: true,
+        },
+      });
+    });
+  });
+
+  describe('isObject', () => {
+    it('returns true if arg is an object', () => {
+      expect(isObject({})).toBe(true);
+      expect(isObject([])).toBe(false);
+    });
+  });
+
+  describe('mergeDeep', () => {
+    it('deep merges two objects', () => {
+      const target = {
+        a: 'test-a',
+        b: {
+          c: 'test-c',
+        },
+      };
+      const source = {
+        one: 'test-one',
+        two: {
+          three: 'test-three',
+        },
+      };
+      const expected = {
+        a: 'test-a',
+        b: {
+          c: 'test-c',
+        },
+        one: 'test-one',
+        two: {
+          three: 'test-three',
+        },
+      };
+      expect(mergeDeep(target, source)).toEqual(expected);
+    });
+  });
+
+  describe('arrayChunks', () => {
+    it('returns an array of chunks each with a length matching the chunkSize', () => {
+      const arr = [1, 2, 3, 4, 5, 6];
+      const size = 2;
+      const expected = [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ];
+      expect(arrayChunks(arr, size)).toEqual(expected);
+    });
+  });
+
+  describe('tryJSONParse', () => {
+    it('returns result of JSON.parse when passed a valid JSON string', () => {
+      const validJSON = '{ "valid": true }';
+      expect(tryJSONParse(validJSON)).toEqual({ valid: true });
+    });
+
+    it('returns the string when passed an invalid JSON string', () => {
+      const invalidJSON = '{ "valid" false}';
+      expect(tryJSONParse(invalidJSON)).toEqual('{ "valid" false}');
+    });
+  });
+
+  describe('tryJSONStringify', () => {
+    it('returns a JSON representation of the data', () => {
+      const validData = { valid: true };
+      expect(tryJSONStringify(validData)).toEqual('{"valid":true}');
+    });
+  });
+
+  describe('loadPackageJSON', () => {
+    it('loads package.json file into an object', () => {
+      expect(loadPackageJSON()).toMatchObject({ author: 'Mike Diarmid' });
+      expect(loadPackageJSON(`${__dirname}/../../`)).toMatchObject({ author: 'Mike Diarmid' });
+      expect(loadPackageJSON('invalid/path')).toBe(undefined);
+      expect(loadPackageJSON('/')).toBe(undefined);
+    });
+  });
+});

--- a/src/__tests__/utils/index.js
+++ b/src/__tests__/utils/index.js
@@ -15,7 +15,7 @@ const { loadPackageJSON,
   throttle,
   getTimeStamp,
   sha1sum,
-} = require('../../utils/index');
+} = require('../../utils/');
 
 const { dateNow, throwError } = require('../../utils/aliases');
 

--- a/src/__tests__/utils/index.js
+++ b/src/__tests__/utils/index.js
@@ -120,7 +120,7 @@ describe('utils', () => {
   describe('isFunction', () => {
     it('returns true if function', () => {
       expect(isFunction(jest.fn())).toBe(true);
-      expect(isFunction('no-a-function')).toBe(false);
+      expect(isFunction('not-a-function')).toBe(false);
     });
   });
 

--- a/src/utils/aliases.js
+++ b/src/utils/aliases.js
@@ -1,7 +1,7 @@
 const dateNow = () => Date.now();
 const throwError = (e) => {
   throw e;
-}
+};
 
 
 module.exports = {

--- a/src/utils/aliases.js
+++ b/src/utils/aliases.js
@@ -1,5 +1,10 @@
 const dateNow = () => Date.now();
+const throwError = (e) => {
+  throw e;
+}
+
 
 module.exports = {
   dateNow,
+  throwError,
 };

--- a/src/utils/aliases.js
+++ b/src/utils/aliases.js
@@ -1,0 +1,5 @@
+const dateNow = () => Date.now();
+
+module.exports = {
+  dateNow,
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -28,6 +28,7 @@ const { createHash } = require('crypto');
 const { sep, join, resolve } = require('path');
 const { Logger, transports } = require('winston');
 const { existsSync, readFileSync } = require('fs');
+const { dateNow } = require('./aliases');
 
 /**
  * Generates from sha1 sum from an object.
@@ -50,7 +51,7 @@ let _timestamp;
 let _ncalls = 0;
 function getTimeStamp() {
   if (!_timestamp || ++_ncalls > 1000) {
-    _timestamp = Date.now();
+    _timestamp = dateNow();
     _ncalls = 0;
     setTimeout(() => {
       _timestamp = null;
@@ -198,7 +199,9 @@ function isObject(item) {
 /**
  * Generate a random integer between two numbers
  * @returns {number}
+ * No point testing a random number generator as tests cannot be deterministic.
  */
+/* istanbul ignore next */
 function randomInt() {
   /* eslint no-bitwise:0 */
   return Math.floor(Math.random() * 0x100000000 | 0).toString(16);


### PR DESCRIPTION
* 100% coverage for the utility functions :tada:
* Added `showcoverage` npm script utility that fires up [http-server](https://www.npmjs.com/package/http-server) with the coverage.  Should make it a bit more friendly for maintainers to get a good overview of test coverage.